### PR TITLE
Limit layout width for readability

### DIFF
--- a/Untitled-1.html
+++ b/Untitled-1.html
@@ -63,7 +63,7 @@
     </style>
 </head>
 <body class="bg-gray-100 font-sans">
-    <div class="flex h-screen overflow-hidden">
+    <div class="flex h-screen overflow-hidden w-full max-w-[1920px] mx-auto px-4 sm:px-6 lg:px-8">
         <!-- Sidebar -->
         <div id="sidebar" class="sidebar bg-gray-800 text-white h-full fixed shadow-lg">
             <div class="p-4 flex items-center justify-between border-b border-gray-700">


### PR DESCRIPTION
## Summary
- constrain main layout to 1920px and center it for better readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c02c5b1308324bf17e4d491926539