### PR TITLE
Improve responsive layout for tables and charts

### DIFF
--- a/Untitled-1.html
+++ b/Untitled-1.html
@@ -284,7 +284,9 @@
                                     <option>2022</option>
                                 </select>
                             </div>
-                            <canvas id="salesChart" height="250"></canvas>
+                            <div class="md:h-[400px] lg:h-[500px] xl:h-[600px]">
+                                <canvas id="salesChart" class="max-w-full"></canvas>
+                            </div>
                         </div>
                         <div class="bg-white rounded-lg shadow p-6">
                             <h3 class="text-lg font-semibold mb-4">Top clients</h3>
@@ -359,7 +361,7 @@
                                 <h3 class="text-lg font-semibold">Dernières factures</h3>
                                 <a href="#" class="text-blue-500 text-sm">Voir tout</a>
                             </div>
-                            <div class="overflow-x-auto">
+                            <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
@@ -416,7 +418,7 @@
                                 <h3 class="text-lg font-semibold">Produits populaires</h3>
                                 <a href="#" class="text-blue-500 text-sm">Voir tout</a>
                             </div>
-                            <div class="overflow-x-auto">
+                            <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
@@ -544,7 +546,7 @@
                                     </select>
                                 </div>
                             </div>
-                            <div class="overflow-x-auto">
+                            <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
@@ -761,7 +763,7 @@
                                     </select>
                                 </div>
                             </div>
-                            <div class="overflow-x-auto">
+                            <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
@@ -961,7 +963,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="overflow-x-auto">
+                            <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
@@ -1131,7 +1133,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="overflow-x-auto">
+                            <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
@@ -1283,7 +1285,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="overflow-x-auto">
+                            <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
@@ -1421,7 +1423,7 @@
                                     </button>
                                 </div>
                             </div>
-                            <div class="overflow-x-auto">
+                            <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
@@ -1538,7 +1540,9 @@
                                     <option>2022</option>
                                 </select>
                             </div>
-                            <canvas id="clientSalesChart" height="300"></canvas>
+                            <div class="md:h-[400px] lg:h-[500px] xl:h-[600px]">
+                                <canvas id="clientSalesChart" class="max-w-full"></canvas>
+                            </div>
                         </div>
                         <div class="bg-white rounded-lg shadow p-6">
                             <div class="flex justify-between items-center mb-4">
@@ -1549,7 +1553,9 @@
                                     <option>2022</option>
                                 </select>
                             </div>
-                            <canvas id="productSalesChart" height="300"></canvas>
+                            <div class="md:h-[400px] lg:h-[500px] xl:h-[600px]">
+                                <canvas id="productSalesChart" class="max-w-full"></canvas>
+                            </div>
                         </div>
                     </div>
                     <div class="bg-white rounded-lg shadow p-6 mb-6">
@@ -1561,7 +1567,9 @@
                                 <option>2022</option>
                             </select>
                         </div>
-                        <canvas id="evolutionChart" height="150"></canvas>
+                        <div class="md:h-[400px] lg:h-[500px] xl:h-[600px]">
+                            <canvas id="evolutionChart" class="max-w-full"></canvas>
+                        </div>
                     </div>
                 </div>
 
@@ -1712,7 +1720,7 @@
                                         <div class="space-y-6">
                                             <div>
                                                 <h3 class="text-lg font-medium mb-4">Gestion des utilisateurs</h3>
-                                                <div class="overflow-x-auto">
+                                                <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                                     <table class="min-w-full divide-y divide-gray-200">
                                                         <thead class="bg-gray-50">
                                                             <tr>
@@ -1798,7 +1806,7 @@
                                         <div class="space-y-6">
                                             <div>
                                                 <h3 class="text-lg font-medium mb-4">Gestion des taxes</h3>
-                                                <div class="overflow-x-auto">
+                                                <div class="overflow-x-auto lg:table-fixed xl:w-full">
                                                     <table class="min-w-full divide-y divide-gray-200">
                                                         <thead class="bg-gray-50">
                                                             <tr>


### PR DESCRIPTION
## Summary
- add responsive `lg:table-fixed` and `xl:w-full` classes to table containers to avoid overflow
- wrap chart canvases with responsive height containers and apply `max-w-full`

## Testing
- `npx --yes htmlhint Untitled-1.html`


------
https://chatgpt.com/codex/tasks/task_e_688c02c6c6248324b45809238974db0c